### PR TITLE
Make diffino pip installable from PyPi

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,0 @@
-include requirements.txt

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include requirements.txt

--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 diffino
 ====
-[![Run Status](https://api.shippable.com/projects/590fc79a8874ee070046b384/badge?branch=master)](https://app.shippable.com/github/ivansabik/diffino)
-[![Coverage Badge](https://api.shippable.com/projects/590fc79a8874ee070046b384/coverageBadge?branch=master)](https://app.shippable.com/github/ivansabik/diffino)
+[![Build Status](https://travis-ci.com/IntuitiveWebSolutions/diffino.svg?branch=master)](https://travis-ci.com/IntuitiveWebSolutions/diffino)
 
 Diffing tools for comparing datasets in CSV, XLSX and other formats available as CLI app, API, web app and module. Powered by the awesome Pandas library for Python.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
-[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)
-
 diffino
 ====
 [![Build Status](https://travis-ci.com/IntuitiveWebSolutions/diffino.svg?branch=master)](https://travis-ci.com/IntuitiveWebSolutions/diffino)
+[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)
 
 Diffing tools for comparing datasets in CSV, XLSX and other formats available as CLI app, API, web app and module. Powered by the awesome Pandas library for Python.
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import os
 from setuptools import setup
 
-VERSION = "0.1.3"
+VERSION = "0.1.4"
 
 with open('requirements.txt') as f:
     required = f.read().splitlines()

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-import pathlib
+import os
 from setuptools import setup
 
 VERSION = "0.1.3"

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,7 @@
 import os
 from setuptools import setup
 
-VERSION = "0.1.4"
-
-with open('requirements.txt') as f:
-    required = f.read().splitlines()
+VERSION = "0.1.5"
 
 def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
@@ -14,7 +11,9 @@ setup(
     version=VERSION,
     packages=["diffino"],
     include_package_data=True,
-    install_requires=required,
+    install_requires=[
+        "pandas==0.24.2"
+    ],
     entry_points={'console_scripts': ['diffino = diffino.cli:main']},
     author="BriteCore",
     description="Diffing tools for comparing datasets in CSV, XLSX and other formats",

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,13 @@
 import pathlib
 from setuptools import setup
 
-VERSION = "0.1.2"
+VERSION = "0.1.3"
 
 with open('requirements.txt') as f:
     required = f.read().splitlines()
 
-# The directory containing this file
-HERE = pathlib.Path(__file__).parent
+def read(fname):
+    return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
 # The text of the README file
 README = (HERE / "README.md").read_text()
@@ -21,7 +21,7 @@ setup(
     entry_points={'console_scripts': ['diffino = diffino.cli:main']},
     author="BriteCore",
     description="Diffing tools for comparing datasets in CSV, XLSX and other formats",
-    long_description=README,
+    long_description=read('README.md'),
     long_description_content_type="text/markdown",
     keywords="diffing comparing csv excel json",
     url="https://github.com/IntuitiveWebSolutions/diffino"

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import pathlib
 from setuptools import setup
 
-VERSION = "0.1.1"
+VERSION = "0.1.2"
 
 with open('requirements.txt') as f:
     required = f.read().splitlines()
@@ -23,5 +23,6 @@ setup(
     description="Diffing tools for comparing datasets in CSV, XLSX and other formats",
     long_description=README,
     long_description_content_type="text/markdown",
-    keywords="diffing comparing csv excel json"
+    keywords="diffing comparing csv excel json",
+    url="https://github.com/IntuitiveWebSolutions/diffino"
 )

--- a/setup.py
+++ b/setup.py
@@ -9,9 +9,6 @@ with open('requirements.txt') as f:
 def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
-# The text of the README file
-README = (HERE / "README.md").read_text()
-
 setup(
     name="diffino",
     version=VERSION,

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 import pathlib
 from setuptools import setup
 
+VERSION = "0.1.1"
 
 with open('requirements.txt') as f:
     required = f.read().splitlines()
@@ -13,7 +14,7 @@ README = (HERE / "README.md").read_text()
 
 setup(
     name="diffino",
-    version="0.1",
+    version=VERSION,
     packages=["diffino"],
     include_package_data=True,
     install_requires=required,

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,26 @@
-from setuptools import find_packages, setup
+import pathlib
+from setuptools import setup
 
 
 with open('requirements.txt') as f:
     required = f.read().splitlines()
 
+# The directory containing this file
+HERE = pathlib.Path(__file__).parent
+
+# The text of the README file
+README = (HERE / "README.md").read_text()
+
 setup(
-    name='diffino',
-    packages=find_packages(),
+    name="diffino",
+    version="0.1",
+    packages=["diffino"],
     include_package_data=True,
     install_requires=required,
-    entry_points={'console_scripts': ['diffino = diffino.cli:main']}
+    entry_points={'console_scripts': ['diffino = diffino.cli:main']},
+    author="BriteCore",
+    description="Diffing tools for comparing datasets in CSV, XLSX and other formats",
+    long_description=README,
+    long_description_content_type="text/markdown",
+    keywords="diffing comparing csv excel json"
 )


### PR DESCRIPTION
This PR adds the setup to publish diffino to PyPi

## Testing

* Search in pypi for the package and confirm it's there https://pypi.org/search/?q=diffino
* Create a virtualenv with 2.7 and another one with 3.6 and confirm that `pip install diffino` it's working and that the tool works as expected