### PR TITLE
Return the row count of left and right diffs

### DIFF
--- a/diffino/models.py
+++ b/diffino/models.py
@@ -182,3 +182,5 @@ class Diffino:
         self.diff_result_right = merged_dataset[exists_right].drop(["exists"], axis=1)
 
         self._build_output()
+
+        return (len(self.diff_result_left.index), len(self.diff_result_right.index))

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import os
 from setuptools import setup
 
-VERSION = "0.1.7"
+VERSION = "0.1.8"
 
 def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -70,12 +70,12 @@ class TestModels(object):
             output_only_diffs=output_only_diffs,
         )
 
-        diffino.build_diff()
+        rows_count = diffino.build_diff()
 
         if not to_console and not output_only_diffs:
             assert os.path.isfile(output_left)
             assert os.path.isfile(output_right)
-        return output_location, output_left, output_right
+        return output_location, output_left, output_right, rows_count
 
     def test_dataset_read_from_local_file(self):
         location = fname = os.path.join(os.path.dirname(__file__), "sample_left.csv")
@@ -151,5 +151,10 @@ eleven st,11"""
         outputs = self._create_diff(
             str(tmpdir), right_csv="sample_left.csv", output_only_diffs=True
         )
-        assert not os.path.isfile(outputs[0])
         assert not os.path.isfile(outputs[1])
+        assert not os.path.isfile(outputs[2])
+
+    def test_diffino_return_diff_count(self, tmpdir):
+        outputs = self._create_diff(str(tmpdir))
+        assert outputs[3][0] is 1
+        assert outputs[3][0] is 1


### PR DESCRIPTION
## Problem
We need a way to communicate to external tools using diffino the amount of rows generated in the left and right diff.

## Solution
Make the `build_diff` method return a tuple containing the diff count for the left in the first index and the diff count for the right as the second index.

## Testing

### Automatic
* Create a virtual environment for the project
* Install dependencies
* Run `pytest tests/test_models.py`